### PR TITLE
Add support for config.listen to be options object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -584,11 +584,23 @@ router.get("/misc", auth, (req, res) => {
 	});
 });
 
-console.log(`Listening on ${config.listen} under path ${pathname}`);
 
 app.use(pathname, router);
-if (typeof config.listen === "string" && isNaN(config.listen)){
-	process.on("exit", () => fs.unlinkSync(config.listen));
-	if (fs.existsSync(config.listen)) fs.unlinkSync(config.listen);
+
+if (typeof config.listen === "object") {
+	if (typeof config.listen.port === "undefined" && typeof config.listen.path === "string" ) {
+		console.log(`Listening on ${config.listen.path} under path ${pathname}`);
+		process.on("exit", () => fs.unlinkSync(config.listen.path));
+		if (fs.existsSync(config.listen.path)) fs.unlinkSync(config.listen.path);
+	} else {
+		console.log(`Listening on ${config.listen.host || ""}:${config.listen.port} under path ${pathname}`);
+	}
+} else {
+	console.log(`Listening on ${config.listen} under path ${pathname}`);
+	if (typeof config.listen === "string" && isNaN(config.listen)){
+		process.on("exit", () => fs.unlinkSync(config.listen));
+		if (fs.existsSync(config.listen)) fs.unlinkSync(config.listen);
+	}
 }
+
 app.listen(config.listen);


### PR DESCRIPTION
This allows advanced end users to use options object specified in https://nodejs.org/api/net.html#net_server_listen_options_callback instead of port/path in listen value inside config.json.

Using object allows user to specify `host`name, `backlog`, make shitty `exclusive` on a handle and in case of socket set it to `readableAll` and/or `writableAll` !