### PR TITLE
Remove the PHP upload restriction

### DIFF
--- a/index.js
+++ b/index.js
@@ -415,7 +415,7 @@ router.post(["/upload","/webshareupload"], (req, res) => {
 		if (exten) ext = "." + exten.ext;
 	}
 
-	if (ext.toLowerCase() === ".php") return error(req, res, "Disallowed file type.");
+	// if (ext.toLowerCase() === ".php") return error(req, res, "Disallowed file type.");
 
 	let name;
 	let attempts = 0;
@@ -541,7 +541,7 @@ router.post("/rename", (req, res) => {
 
 	if (!fs.existsSync(filePath)) return error(req, res, "File don't exist");
 	if (fs.existsSync(`${config.imagePath}/${name}`)) return error(req, res, "Filename already in use.");
-	if (path.extname(name).toLowerCase() === ".php") return error(req, res, "Disallowed file type.");
+	// if (path.extname(name).toLowerCase() === ".php") return error(req, res, "Disallowed file type.");
 
 	moveFile( filePath , `${config.imagePath}/${name}`, err => {
 		if (err) {error(req, res, "Rename Failed."); return console.log(JSON.stringify(err));}


### PR DESCRIPTION
I think that the PHP upload restriction is no longer necessary. It's ported up from legacy code (the original shitty.dl was a fork of [unchi](https://github.com/gregoreth/unchi), which was written in PHP). Any reasonable host would not be allowing PHP execution on their shitty.dl instance anyway (as it's configured as a Node.JS proxy), and I run into this restriction often when attempting to paste PHP code. Curious to hear your thoughts.