### PR TITLE
Add page that displays all items to the filelistings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -749,7 +749,7 @@ function fileListing(mask, pageTemplate, route, req, res) {
 
 	let page = typeof req.params.page !== "undefined" ? parseInt(req.params.page) : 0;
 	let displayAll = (page == -1);
-	page = Math.min(Math.max(0, page), Math.floor(files.length/48));
+	page = Math.min(Math.max(1, page), Math.ceil(files.length/48));
 
 	const paginationInfo = paginator.build(files.length, page);
 

--- a/index.js
+++ b/index.js
@@ -748,7 +748,8 @@ function fileListing(mask, pageTemplate, route, req, res) {
 	const files = finder.findFiles(mask);
 
 	let page = typeof req.params.page !== "undefined" ? parseInt(req.params.page) : 0;
-	page = Math.min(Math.max(0, page), files.length);
+	let displayAll = (page == -1);
+	page = Math.min(Math.max(0, page), Math.floor(files.length/48));
 
 	const paginationInfo = paginator.build(files.length, page);
 
@@ -786,7 +787,7 @@ function fileListing(mask, pageTemplate, route, req, res) {
 		query: url.parse(req.url).query,
 		paginationInfo,
 		pages: _.range(paginationInfo.first_page, paginationInfo.last_page + 1),
-		files: _.slice(fullFiles, paginationInfo.first_result, paginationInfo.last_result + 1),
+		files: displayAll ? fullFiles : _.slice(fullFiles, paginationInfo.first_result, paginationInfo.last_result + 1),
 		imageFilesFilter,
 		audioFilesFilter,
 		videoFilesFilter,

--- a/index.js
+++ b/index.js
@@ -747,9 +747,16 @@ function fileListing(mask, pageTemplate, route, req, res) {
 	if (pageTemplate == "links") finder.size('<=', maxUrlSize);
 	const files = finder.findFiles(mask);
 
-	let page = typeof req.params.page !== "undefined" ? parseInt(req.params.page) : 0;
-	let displayAll = (page == -1);
-	page = Math.min(Math.max(1, page), Math.ceil(files.length/48));
+	let page = typeof req.params.page !== "undefined" ? req.params.page : 1;
+	let displayAll = false;
+	if (page == "all") {
+		displayAll = true;
+		page = 1;
+	} else if (page == "random") {
+		page = Math.floor(Math.random() * Math.ceil(files.length/48)) + 1;
+	} else {
+		page = Math.min(Math.max(1, parseInt(page)), Math.ceil(files.length/48));
+	}
 
 	const paginationInfo = paginator.build(files.length, page);
 

--- a/views/partials/pagination.hbs
+++ b/views/partials/pagination.hbs
@@ -1,5 +1,5 @@
 <p class="ui extra">
-	<b>{{addCommas paginationInfo.total_results}}</b> total results - <b>{{addCommas paginationInfo.total_pages}}</b> pages
+	<b>{{addCommas paginationInfo.total_results}}</b> total results - <b>{{addCommas paginationInfo.total_pages}}</b> pages - <a href="{{@root.route}}/all{{#if @root.query}}?{{@root.query}}{{/if}}">View all</a>
 </p>
 <div class="ui buttons">
 	<a href="{{@root.route}}/{{paginationInfo.previous_page}}{{#if @root.query}}?{{@root.query}}{{/if}}" class="ui icon button pageLeft {{#unless paginationInfo.has_previous_page}}disabled{{/unless}}">


### PR DESCRIPTION
Allows to see all files for the category or all files for specific query skipping the pagination. Useful when looking for specific file.